### PR TITLE
add feature for fetching a specific meetup record

### DIFF
--- a/controllers/meetupControllers.js
+++ b/controllers/meetupControllers.js
@@ -32,6 +32,29 @@ class meetup{
 	}
 
 
+	static fetchMeetup(req, res){
+		const meetupId = meetupRecords.find(c => c.id === parseInt(req.params.id));
+		if(!meetupId)
+			return res.status(404).send({
+				status:404,
+				error : 'No such meetup Can Be Found'
+			});
+
+		const {id, topic, location, happeningOn, tags} = meetupId;
+
+		res.send({
+			status:201,
+			data : [{
+				id,
+				topic,
+				location,
+				happeningOn,
+				tags
+			}]
+		})
+	}
+
+
 
 }
 

--- a/routes/meetupRoutes.js
+++ b/routes/meetupRoutes.js
@@ -4,6 +4,7 @@ import meetupControllers from '../controllers/meetupControllers';
 const router = express.Router();
 
 router.post('/meetups', meetupControllers.create);
+router.get('/meetups/:id', meetupControllers.fetchMeetup);
 
 
 export default router;


### PR DESCRIPTION
this feature will allow a user to fetch a specific meetup record by entering 'api/v1/users/meetups/<a number>' endpoint url.

![fetching a single data --on error](https://user-images.githubusercontent.com/37753967/50489165-d9b74f80-0a0e-11e9-87bc-385fa2a3caf9.PNG)

![feature a single meetup](https://user-images.githubusercontent.com/37753967/50489095-6ca3ba00-0a0e-11e9-9c5e-b948399b9246.PNG)
